### PR TITLE
Fallback to fromSequenceNr instead of to 0L

### DIFF
--- a/src/main/scala/akka/persistence/journal/redis/RedisJournal.scala
+++ b/src/main/scala/akka/persistence/journal/redis/RedisJournal.scala
@@ -89,7 +89,7 @@ class RedisJournal(conf: Config) extends AsyncWriteJournal {
 
   def asyncReadHighestSequenceNr(persistenceId: String, fromSequenceNr: Long): Future[Long] =
     for (highestStored <- redis.get[Long](highestSequenceNrKey(persistenceId)))
-      yield highestStored.getOrElse(0L)
+      yield highestStored.getOrElse(fromSequenceNr)
 
   def asyncReplayMessages(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long)(recoveryCallback: PersistentRepr => Unit): Future[Unit] =
     for {


### PR DESCRIPTION
A fix to prevent overwriting lastSequenceNr of snapshot to `0L` in case that highest sequenceNr is not found in Redis db.

### Expected behavior (after this fix)

1. On snapshot loaded, lastSequenceNr is set to sequenceNr of the loaded snapshot.
2. akka-persistence-redis tries to load journal, but could not find highestSequenceNr in Redis db.
3. sequenceNr should be unchanged.

### Actual behavior (befor this fix)

1. On snapshot loaded, lastSequenceNr is set to sequenceNr of the loaded snapshot.
2. akka-persistence-redis tries to load journal, but could not find highestSequenceNr in Redis db.
3. sequenceNr has been overwritten to `0L` 