### PR TITLE
Remove useless tags key

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.15

--- a/src/main/scala/akka/persistence/journal/redis/RedisJournal.scala
+++ b/src/main/scala/akka/persistence/journal/redis/RedisJournal.scala
@@ -141,7 +141,6 @@ class RedisJournal(conf: Config) extends AsyncWriteJournal {
           .zip(Future.sequence(tags.map { t =>
             transaction
               .rpush(tagKey(t), f"${pr.sequenceNr}:${pr.persistenceId}")
-              .zip(transaction.sadd(tagsKey, t))
               // notify about new event being appended for this tag
               .zip(transaction.publish(tagsChannel, t))
           }))

--- a/src/main/scala/akka/persistence/redis/RedisKeys.scala
+++ b/src/main/scala/akka/persistence/redis/RedisKeys.scala
@@ -19,7 +19,6 @@ package redis
 
 object RedisKeys {
   val identifiersKey = "journal:persistenceIds"
-  val tagsKey = "journal:tags"
   def highestSequenceNrKey(persistenceId: String) = f"journal:persisted:$persistenceId:highestSequenceNr"
   def journalKey(persistenceId: String) = f"journal:persisted:$persistenceId"
   def journalChannel(persistenceId: String) = f"journal:channel:persisted:$persistenceId"


### PR DESCRIPTION
This key of all tags has no use. Memory space can be spared by removing
this key. It would have a use in the eventuality of a stream of all
tags.

Fix #7