### PR TITLE
Get current events at the time stream is opened

### DIFF
--- a/src/main/scala/akka/persistence/query/journal/redis/ScalaReadJournal.scala
+++ b/src/main/scala/akka/persistence/query/journal/redis/ScalaReadJournal.scala
@@ -85,7 +85,13 @@ class ScalaReadJournal private[redis] (system: ExtendedActorSystem, conf: Config
   /** Returns the stream of current events with a given tag.
    *  The events are sorted in the order they occurred, you can rely on it.
    *
-   *  Once there are no more events in the store, the stream is closed, not waiting for new ones.
+   *  Returned events are those present in the store with the given tag at the time
+   *  the stream is opened.
+   *
+   *  Events deleted during this stream life might not appear in the stream if not delivered yet.
+   *
+   *  Stream is closed once all events present at the time of opening have been delivered.
+   *
    */
   def currentEventsByTag(tag: String, offset: Offset): Source[EventEnvelope, NotUsed] = offset match {
     case NoOffset =>

--- a/src/test/scala/akka/persistence/query/journal/redis/EventsByPersistenceIdSpec.scala
+++ b/src/test/scala/akka/persistence/query/journal/redis/EventsByPersistenceIdSpec.scala
@@ -82,7 +82,7 @@ class EventsByPersistenceIdSpec extends AkkaSpec(EventsByPersistenceIdSpec.confi
         .expectComplete()
     }
 
-    "not see new events after completion" in {
+    "not see new events after opening" in {
       val ref = setup("f")
       val src = queries.currentEventsByPersistenceId("f", 0L, Long.MaxValue)
       val probe = src.map(_.event).runWith(TestSink.probe[Any])
@@ -90,14 +90,14 @@ class EventsByPersistenceIdSpec extends AkkaSpec(EventsByPersistenceIdSpec.confi
         .expectNext("f-1", "f-2")
         .expectNoMsg(100.millis)
 
+      ref ! "f-4"
+      expectMsg("f-4-done")
+
       probe
         .expectNoMsg(100.millis)
         .request(5)
         .expectNext("f-3")
         .expectComplete() // f-4 not seen
-
-      ref ! "f-4"
-      expectMsg("f-4-done")
 
     }
 

--- a/src/test/scala/akka/persistence/query/journal/redis/EventsByTagSpec.scala
+++ b/src/test/scala/akka/persistence/query/journal/redis/EventsByTagSpec.scala
@@ -98,7 +98,7 @@ class EventsByTagSpec extends AkkaSpec(EventsByTagSpec.config)
         .expectComplete()
     }
 
-    "not see new events after complete" in {
+    "not see new events after opening" in {
       val c = system.actorOf(TestActor.props("c"))
 
       val greenSrc = queries.currentEventsByTag(tag = "green", offset = Sequence(0L))
@@ -108,14 +108,15 @@ class EventsByTagSpec extends AkkaSpec(EventsByTagSpec.config)
         .expectNext(EventEnvelope(Sequence(1L), "a", 3L, "a green banana"))
         .expectNoMsg(100.millis)
 
+      c ! "a green cucumber"
+      expectMsg(s"a green cucumber-done")
+
       probe
         .expectNoMsg(100.millis)
         .request(5)
         .expectNext(EventEnvelope(Sequence(2L), "b", 2L, "a green leaf"))
         .expectComplete() // green cucumber not seen
 
-      c ! "a green cucumber"
-      expectMsg(s"a green cucumber-done")
     }
 
     "find events from offset (inclusive)" in {


### PR DESCRIPTION
The semantics of current events stream is as follows: delivered events
are those that were present at the time the stream was opened.
Guarantee is that all events present during the entire stream life will
be delivered. If elements are removed before delivery, they might not be
delivered at all (due to batching).

Fix #6.