### PR TITLE
Fix pagination for events by persistence id

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/src/main/scala/akka/persistence/query/journal/redis/EventsByPersistenceIdSource.scala
+++ b/src/main/scala/akka/persistence/query/journal/redis/EventsByPersistenceIdSource.scala
@@ -246,7 +246,7 @@ private class EventsByPersistenceIdSource(conf: Config, redis: RedisClient, pers
             if (buffer.isEmpty) {
               // so, we need to fill this buffer
               state = Querying
-              redis.zrangebyscore[Array[Byte]](journalKey(persistenceId), Limit(currentSequenceNr), Limit(math.min(currentSequenceNr + max - 1, to))).onComplete {
+              redis.zrangebyscore[Array[Byte]](journalKey(persistenceId), Limit(currentSequenceNr), Limit(to), Some(0l -> max)).onComplete {
                 case Success(events) =>
                   callback.invoke(events.map(persistentFromBytes(_)))
                 case Failure(t) =>


### PR DESCRIPTION
Always query the event between the last known sequence number and the
upper limit, instead of the sequence number in a page range after the
last known number. Using the `limit` parameter to the query makes it
possible to retrieve batches of the desired size.

The previous method ignored higher number if the lower sequence numbers
were missing, and considered the source done so far.

Fix #11