### PR TITLE
Only call stage methods in callbacks

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/src/main/scala/akka/persistence/query/journal/redis/CurrentPersistenceIdsSource.scala
+++ b/src/main/scala/akka/persistence/query/journal/redis/CurrentPersistenceIdsSource.scala
@@ -79,7 +79,8 @@ private class CurrentPersistenceIdsSource(redis: RedisClient) extends GraphStage
                 callback.invoke(cursor)
               case Failure(t) =>
                 log.error(t, "Error while querying persistence identifiers")
-                failStage(t)
+                val cb = getAsyncCallback[Unit] { _ => failStage(t) }
+                cb.invoke(())
             }
 
           } else {

--- a/src/main/scala/akka/persistence/query/journal/redis/EventsByTagSource.scala
+++ b/src/main/scala/akka/persistence/query/journal/redis/EventsByTagSource.scala
@@ -204,7 +204,8 @@ private class EventsByTagSource(conf: Config, redis: RedisClient, tag: String, o
               initCallback.invoke(len - 1)
             case Failure(t) =>
               log.error(t, "Error while initializing current events by tag")
-              failStage(t)
+              val cb = getAsyncCallback[Unit] { _ => failStage(t) }
+              cb.invoke(())
           }
         }
 
@@ -251,7 +252,8 @@ private class EventsByTagSource(conf: Config, redis: RedisClient, tag: String, o
                   callback.invoke((nb, events))
                 case Failure(t) =>
                   log.error(t, "Error while querying events by persistence identifier")
-                  failStage(t)
+                  val cb = getAsyncCallback[Unit] { _ => failStage(t) }
+                  cb.invoke(())
               }
             } else {
               // buffer is non empty, let’s deliver buffered data

--- a/src/main/scala/akka/persistence/query/journal/redis/PersistenceIdsSource.scala
+++ b/src/main/scala/akka/persistence/query/journal/redis/PersistenceIdsSource.scala
@@ -110,7 +110,8 @@ private class PersistenceIdsSource(conf: Config, redis: RedisClient, system: Act
                 callback.invoke(cursor)
               case Failure(t) =>
                 log.error(t, "Error while querying persistence identifiers")
-                failStage(t)
+                val cb = getAsyncCallback[Unit] { _ => failStage(t) }
+                cb.invoke(())
             }
 
           } else if (buffer.isEmpty) {


### PR DESCRIPTION
Calling a stage method such as `completeStage` in a random `Future`
callback method makes the implementation break the guidelines and
unreliable.

Fix #14