### PR TITLE
Sentinels as string

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -64,6 +64,12 @@ akka-persistence-redis {
   #       port = 1235
   #     }
   #   ]
+  #
+  # or if the sentinels are only available in one connection string
+  # like "host1:1234,host2:1235"
+  #
+  #    sentinel-list = "host1:1234,host2:1235"
+  #
   # }
 
   # The journal component settings.

--- a/src/main/scala/akka/persistence/redis/RedisUtils.scala
+++ b/src/main/scala/akka/persistence/redis/RedisUtils.scala
@@ -54,7 +54,8 @@ object RedisUtils {
               .getConfigList("redis.sentinels")
               .asScala
               .map(c => (c.getString("host"), c.getInt("port")))
-          } else {conf
+          } else {
+            conf
               .getString("redis.sentinel-list")
               .split(",")
               .map(HostAndPort.apply)

--- a/src/main/scala/akka/persistence/redis/RedisUtils.scala
+++ b/src/main/scala/akka/persistence/redis/RedisUtils.scala
@@ -18,27 +18,30 @@ package persistence
 package redis
 
 import actor._
-
 import _root_.redis._
-
+import akka.persistence.utils.HostAndPort
 import com.typesafe.config.Config
 
 import scala.collection.JavaConverters._
 
 object RedisUtils {
 
-  def host(conf: Config) = conf.getString("redis.host")
+  def host(conf: Config): String = conf.getString("redis.host")
 
-  def port(conf: Config) = conf.getInt("redis.port")
+  def port(conf: Config): Int = conf.getInt("redis.port")
 
-  def database(conf: Config) = if (conf.hasPath("redis.database")) Some(conf.getInt("redis.database")) else None
+  def database(conf: Config): Option[Int] =
+    if (conf.hasPath("redis.database")) Some(conf.getInt("redis.database"))
+    else None
 
-  def password(conf: Config) = if (conf.hasPath("redis.password")) Some(conf.getString("redis.password")) else None
+  def password(conf: Config): Option[String] =
+    if (conf.hasPath("redis.password")) Some(conf.getString("redis.password"))
+    else None
 
   def create(conf: Config)(implicit system: ActorSystem): RedisClient =
     conf.getString("redis.mode") match {
       case "simple" =>
-        new RedisClient(
+        RedisClient(
           host = host(conf),
           port = port(conf),
           db = database(conf),
@@ -46,12 +49,23 @@ object RedisUtils {
 
       case "sentinel" =>
         val sentinels =
-          conf
-            .getConfigList("redis.sentinels")
-            .asScala
-            .map(c => (c.getString("host"), c.getInt("port")))
-            .toSeq
-        new SentinelMonitoredRedisClient(sentinels = sentinels, master = conf.getString("redis.master"), db = database(conf), password = password(conf)).redisClient
+          if (conf.hasPath("redis.sentinels")) {
+            conf
+              .getConfigList("redis.sentinels")
+              .asScala
+              .map(c => (c.getString("host"), c.getInt("port")))
+          } else {conf
+              .getString("redis.sentinel-list")
+              .split(",")
+              .map(HostAndPort.apply)
+              .map(_.asTuple)
+              .toSeq
+          }
+        SentinelMonitoredRedisClient(
+          sentinels = sentinels,
+          master = conf.getString("redis.master"),
+          db = database(conf),
+          password = password(conf)).redisClient
 
       case mode =>
         throw new Exception(f"Unsupported redis mode $mode")

--- a/src/main/scala/akka/persistence/utils/HostAndPort.scala
+++ b/src/main/scala/akka/persistence/utils/HostAndPort.scala
@@ -19,12 +19,6 @@ package akka.persistence.utils
  */
 case class HostAndPort private (host: String, portOpt: Option[Int]) {
 
-  // construction assertion
-  portOpt match {
-    case Some(p) => require(isValidPort(p))
-    case _       =>
-  }
-
   /** Get the port value or if not set the defaultPort value
    *  @param defaultPort the default to return if port is not set
    *  @return the port or the default

--- a/src/main/scala/akka/persistence/utils/HostAndPort.scala
+++ b/src/main/scala/akka/persistence/utils/HostAndPort.scala
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package akka.persistence.utils
+
+/** Convenience class for holding host and port tuples and not having to depend on Guava.
+ *  @param host the hostname
+ *  @param portOpt the (optional) port
+ */
+case class HostAndPort private (host: String, portOpt: Option[Int]) {
+
+  // construction assertion
+  portOpt match {
+    case Some(p) => require(isValidPort(p))
+    case _       =>
+  }
+
+  /** Get the port value or if not set the defaultPort value
+   *  @param defaultPort the default to return if port is not set
+   *  @return the port or the default
+   */
+  def portOrDefault(defaultPort: Int): Int = portOpt match {
+    case Some(p) => p
+    case None    => defaultPort
+  }
+
+  /** Get the port or a negative fallback value
+   *  @return the port or a negative fallback
+   */
+  def port: Int = portOrDefault(HostAndPort.noPortFallback)
+
+  /** Returns the host and port as a tuple (String, Int)
+   *  @return the tuple
+   */
+  def asTuple: (String, Int) = (host, port)
+
+  private def isValidPort(port: Int) = port >= 0 && port <= 65535
+
+  override def toString: String =
+    portOpt match {
+      case Some(p) => s"$host:$p"
+      case None    => host
+    }
+}
+
+/** Companion Object to create HostAndPort instances either from string or from host, port
+ */
+object HostAndPort {
+
+  val noPortFallback: Int = -1
+
+  /** Create hostAndPort from a String like <host>:<port> or <host>
+   *
+   *  @param hostPortString like <host>:<port> or <host>
+   *  @return the HostAndPort
+   */
+  def apply(hostPortString: String): HostAndPort = {
+    require(hostPortString != null)
+    require(hostPortString.nonEmpty)
+    require(validString(hostPortString))
+
+    val parts = hostPortString.split(":")
+    parts match {
+      case Array(host, port) =>
+        new HostAndPort(host, Some(Integer.parseInt(port)))
+      case Array(host) =>
+        new HostAndPort(host, None)
+    }
+  }
+
+  private def validString(hostPortString: String) =
+    hostPortString.split(":").length <= 2
+
+}

--- a/src/test/scala/akka/persistence/redis/RedisUtilsSpec.scala
+++ b/src/test/scala/akka/persistence/redis/RedisUtilsSpec.scala
@@ -1,0 +1,42 @@
+package akka.persistence.redis
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.{ FlatSpec, Matchers }
+
+class RedisUtilsSpec extends FlatSpec with Matchers {
+
+  "A RedisClient" should "use redis.sentinels as config if sentinel-list is also present" in {
+    val config = ConfigFactory.parseString(s"""
+         |redis {
+         |  mode = sentinel
+         |  master = foo
+         |  database = 0
+         |  sentinel-list = "host1:1234,host2:1235"
+         |  sentinels = [
+         |   {
+         |     host = "host3"
+         |     port = 1236
+         |    },
+         |    {
+         |      host = "host4"
+         |      port = 1237
+         |     }
+         |   ]
+         |}""".stripMargin)
+    val sentinels = RedisUtils.sentinels(config)
+    assert(sentinels.contains(List(("host3", 1236), ("host4", 1237))))
+  }
+
+  it should "use redis.sentinel-list if redis.sentinels is not present" in {
+    val config = ConfigFactory.parseString(s"""
+      |redis {
+      |  mode = sentinel
+      |  master = foo
+      |  database = 0
+      |  sentinel-list = "host1:1234,host2:1235"
+      |}""".stripMargin)
+    val sentinels = RedisUtils.sentinels(config)
+    assert(sentinels.contains(List(("host1", 1234), ("host2", 1235))))
+  }
+
+}

--- a/src/test/scala/akka/persistence/redis/RedisUtilsSpec.scala
+++ b/src/test/scala/akka/persistence/redis/RedisUtilsSpec.scala
@@ -24,7 +24,7 @@ class RedisUtilsSpec extends FlatSpec with Matchers {
          |   ]
          |}""".stripMargin)
     val sentinels = RedisUtils.sentinels(config)
-    assert(sentinels.contains(List(("host3", 1236), ("host4", 1237))))
+    sentinels should be(Some(List(("host3", 1236), ("host4", 1237))))
   }
 
   it should "use redis.sentinel-list if redis.sentinels is not present" in {
@@ -36,7 +36,7 @@ class RedisUtilsSpec extends FlatSpec with Matchers {
       |  sentinel-list = "host1:1234,host2:1235"
       |}""".stripMargin)
     val sentinels = RedisUtils.sentinels(config)
-    assert(sentinels.contains(List(("host1", 1234), ("host2", 1235))))
+    sentinels should be(Some(List(("host1", 1234), ("host2", 1235))))
   }
 
 }

--- a/src/test/scala/akka/persistence/redis/RedisUtilsSpec.scala
+++ b/src/test/scala/akka/persistence/redis/RedisUtilsSpec.scala
@@ -24,7 +24,7 @@ class RedisUtilsSpec extends FlatSpec with Matchers {
          |   ]
          |}""".stripMargin)
     val sentinels = RedisUtils.sentinels(config)
-    sentinels should be(Some(List(("host3", 1236), ("host4", 1237))))
+    sentinels should be(List(("host3", 1236), ("host4", 1237)))
   }
 
   it should "use redis.sentinel-list if redis.sentinels is not present" in {
@@ -36,7 +36,7 @@ class RedisUtilsSpec extends FlatSpec with Matchers {
       |  sentinel-list = "host1:1234,host2:1235"
       |}""".stripMargin)
     val sentinels = RedisUtils.sentinels(config)
-    sentinels should be(Some(List(("host1", 1234), ("host2", 1235))))
+    sentinels should be(List(("host1", 1234), ("host2", 1235)))
   }
 
 }

--- a/src/test/scala/akka/persistence/utils/HostAndPortSpec.scala
+++ b/src/test/scala/akka/persistence/utils/HostAndPortSpec.scala
@@ -1,0 +1,36 @@
+package akka.persistence.utils
+
+import org.scalatest.{ FlatSpec, Matchers }
+
+class HostAndPortSpec extends FlatSpec with Matchers {
+
+  "A HostAndPort" should "have localhost as host and 8080 as port" in {
+    val hostAndPort = HostAndPort("localhost:8080")
+    assert(hostAndPort.host == "localhost")
+    assert(hostAndPort.port == 8080)
+  }
+
+  it should "return a tuple (String, Int)" in {
+    val hostAndPort = HostAndPort("my.host.name:10001")
+    assert(hostAndPort.asTuple == ("my.host.name", 10001))
+  }
+
+  it should "return 8080 instead of 9090" in {
+    val hostAndPort = HostAndPort("localhost:8080")
+    assert(hostAndPort.portOrDefault(9090) == 8080)
+  }
+
+  it should "throw an IllegalArgumentException if the port is negative" in {
+    a[IllegalArgumentException] should be thrownBy {
+      HostAndPort("localhost:-1")
+    }
+
+  }
+
+  it should "throw an IllegalArgumentException if the port is too high" in {
+    a[IllegalArgumentException] should be thrownBy {
+      HostAndPort("localhost:65536")
+    }
+  }
+
+}

--- a/src/test/scala/akka/persistence/utils/HostAndPortSpec.scala
+++ b/src/test/scala/akka/persistence/utils/HostAndPortSpec.scala
@@ -20,17 +20,4 @@ class HostAndPortSpec extends FlatSpec with Matchers {
     assert(hostAndPort.portOrDefault(9090) == 8080)
   }
 
-  it should "throw an IllegalArgumentException if the port is negative" in {
-    a[IllegalArgumentException] should be thrownBy {
-      HostAndPort("localhost:-1")
-    }
-
-  }
-
-  it should "throw an IllegalArgumentException if the port is too high" in {
-    a[IllegalArgumentException] should be thrownBy {
-      HostAndPort("localhost:65536")
-    }
-  }
-
 }


### PR DESCRIPTION
This PR adds support for passing Redis Sentinels as a comma separated string of multiple host:port combinations. In our use case we need to be able to configure a dynamic list of sentinels and do not necessarily know how many instances we've got. 

Would be great if you'd merge it back. 
Questions and/or improvements are welcome.  