### PR TITLE
Upgrade to Scala 2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: scala
 scala:
-   2.12.1
+   - 2.13.0
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 # only trigger builds on master
 branches:

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,8 @@
 import scalariform.formatter.preferences._
 
-val akkaVersion = "2.5.17"
-val redisScalaVersion = "1.8.4"
+val akkaVersion = "2.5.25"
+val redisScalaVersion = "1.9.0"
+val scalaCollectionCompatVersion = "2.1.2"
 
 lazy val publishSettings = Seq(
   publishMavenStyle := true,
@@ -39,10 +40,11 @@ lazy val siteSettings = Seq(
 lazy val dependencies = Seq(
   "com.typesafe.akka" %% "akka-persistence" % akkaVersion,
   "com.typesafe.akka" %% "akka-persistence-query" % akkaVersion,
-  "com.github.Ma27" %% "rediscala" % redisScalaVersion,
+  "com.github.etaty" %% "rediscala" % redisScalaVersion,
+  "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
   "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion % "test",
   "com.typesafe.akka" %% "akka-persistence-tck" % akkaVersion % "test",
-  "com.github.pocketberserker" %% "scodec-msgpack" % "0.6.0" % "test")
+  "com.github.xuwei-k" %% "scodec-msgpack" % "0.7.0" % "test")
 
 lazy val root = project.in(file("."))
   .enablePlugins(SiteScaladocPlugin, GhpagesPlugin)
@@ -57,8 +59,8 @@ lazy val root = project.in(file("."))
     licenses += ("The Apache Software License, Version 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt")),
     homepage := Some(url("https://github.com/safety-data/akka-persistence-redis")),
     scmInfo := Some(ScmInfo(url("https://github.com/safety-data/akka-persistence-redis"), "git@github.com:safety-data/akka-persistence-redis.git")),
-    scalaVersion := "2.12.7",
-    crossScalaVersions := Seq("2.12.7", "2.11.12"),
+    scalaVersion := "2.13.0",
+    crossScalaVersions := Seq("2.13.0", "2.12.9", "2.11.12"),
     libraryDependencies ++= dependencies,
     parallelExecution in Test := false,
     scalacOptions in (Compile,doc) ++= Seq("-groups", "-implicits", "-implicits-show-all", "-diagrams", "-doc-title", "Akka Persistence Redis", "-doc-version", version.value, "-doc-footer", "Copyright © 2017 Safety Data"),

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.1
+sbt.version=1.3.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.3.2")
+addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.0")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.2")
+addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.3")

--- a/src/main/scala/akka/persistence/journal/redis/RedisJournal.scala
+++ b/src/main/scala/akka/persistence/journal/redis/RedisJournal.scala
@@ -77,12 +77,12 @@ class RedisJournal(conf: Config) extends AsyncWriteJournal {
 
   var redis: RedisClient = _
 
-  override def preStart() {
+  override def preStart(): Unit = {
     redis = RedisUtils.create(conf)
     super.preStart()
   }
 
-  override def postStop() {
+  override def postStop(): Unit = {
     redis.stop()
     super.postStop()
   }

--- a/src/main/scala/akka/persistence/query/journal/redis/CurrentPersistenceIdsSource.scala
+++ b/src/main/scala/akka/persistence/query/journal/redis/CurrentPersistenceIdsSource.scala
@@ -69,7 +69,7 @@ private class CurrentPersistenceIdsSource(redis: RedisClient) extends GraphStage
                 // it is not the start anymore
                 start = false
                 // enqueue received data
-                buffer.enqueue(data: _*)
+                buffer ++= data
                 // deliver element
                 deliver()
             }

--- a/src/main/scala/akka/persistence/query/journal/redis/EventsByPersistenceIdSource.scala
+++ b/src/main/scala/akka/persistence/query/journal/redis/EventsByPersistenceIdSource.scala
@@ -142,7 +142,7 @@ private class EventsByPersistenceIdSource(conf: Config, redis: RedisClient, pers
             currentSequenceNr = maxSequenceNr
             log.debug(f"Max sequence number is now $maxSequenceNr")
             if (evts.nonEmpty) {
-              buffer.enqueue(evts: _*)
+              buffer ++= evts
               deliver()
             } else {
               // requery immediately
@@ -250,7 +250,7 @@ private class EventsByPersistenceIdSource(conf: Config, redis: RedisClient, pers
             if (buffer.isEmpty) {
               // so, we need to fill this buffer
               state = Querying
-              redis.zrangebyscore[Array[Byte]](journalKey(persistenceId), Limit(currentSequenceNr), Limit(to), Some(0l -> max)).onComplete {
+              redis.zrangebyscore[Array[Byte]](journalKey(persistenceId), Limit(currentSequenceNr), Limit(to), Some(0L -> max)).onComplete {
                 case Success(events) =>
                   callback.invoke(events.map(persistentFromBytes(_)))
                 case Failure(t) =>

--- a/src/main/scala/akka/persistence/query/journal/redis/EventsByTagSource.scala
+++ b/src/main/scala/akka/persistence/query/journal/redis/EventsByTagSource.scala
@@ -133,7 +133,7 @@ private class EventsByTagSource(conf: Config, redis: RedisClient, tag: String, o
               }
               currentOffset += nb
               if (evts.nonEmpty) {
-                buffer.enqueue(evts: _*)
+                buffer ++= evts
                 deliver()
               } else {
                 // requery immediately

--- a/src/main/scala/akka/persistence/query/journal/redis/PersistenceIdsSource.scala
+++ b/src/main/scala/akka/persistence/query/journal/redis/PersistenceIdsSource.scala
@@ -100,7 +100,7 @@ private class PersistenceIdsSource(conf: Config, redis: RedisClient, system: Act
                 // it is not the start anymore
                 start = false
                 // enqueue received data
-                buffer.enqueue(data: _*)
+                buffer ++= data
                 // deliver element
                 deliver()
             }

--- a/src/main/scala/akka/persistence/query/journal/redis/ScalaReadJournal.scala
+++ b/src/main/scala/akka/persistence/query/journal/redis/ScalaReadJournal.scala
@@ -75,7 +75,7 @@ class ScalaReadJournal private[redis] (system: ExtendedActorSystem, conf: Config
    */
   def eventsByTag(tag: String, offset: Offset): Source[EventEnvelope, NotUsed] = offset match {
     case NoOffset =>
-      Source.fromGraph(new EventsByTagSource(conf, redis, tag, 0l, system, true))
+      Source.fromGraph(new EventsByTagSource(conf, redis, tag, 0L, system, true))
     case Sequence(offsetValue) =>
       Source.fromGraph(new EventsByTagSource(conf, redis, tag, offsetValue, system, true))
     case _ =>
@@ -95,7 +95,7 @@ class ScalaReadJournal private[redis] (system: ExtendedActorSystem, conf: Config
    */
   def currentEventsByTag(tag: String, offset: Offset): Source[EventEnvelope, NotUsed] = offset match {
     case NoOffset =>
-      Source.fromGraph(new EventsByTagSource(conf, redis, tag, 0l, system, false))
+      Source.fromGraph(new EventsByTagSource(conf, redis, tag, 0L, system, false))
     case Sequence(offsetValue) =>
       Source.fromGraph(new EventsByTagSource(conf, redis, tag, offsetValue, system, false))
     case _ =>

--- a/src/main/scala/akka/persistence/redis/RedisUtils.scala
+++ b/src/main/scala/akka/persistence/redis/RedisUtils.scala
@@ -22,7 +22,7 @@ import _root_.redis._
 import akka.persistence.utils.HostAndPort
 import com.typesafe.config.Config
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 object RedisUtils {
 
@@ -48,6 +48,7 @@ object RedisUtils {
         .getConfigList("redis.sentinels")
         .asScala
         .map(c => (c.getString("host"), c.getInt("port")))
+        .toSeq
     } else {
       conf
         .getString("redis.sentinel-list")

--- a/src/test/scala/akka/persistence/query/journal/redis/AllPersistenceIdsSpec.scala
+++ b/src/test/scala/akka/persistence/query/journal/redis/AllPersistenceIdsSpec.scala
@@ -76,7 +76,7 @@ class AllPersistenceIdsSpec extends AkkaSpec(AllPersistenceIdsSpec.config)
         probe.expectNext("e")
 
         val more = (1 to 100).map("f" + _)
-        more.foreach { p ⇒
+        more.foreach { p =>
           system.actorOf(TestActor.props(p)) ! p
         }
 

--- a/src/test/scala/akka/persistence/query/journal/redis/Cleanup.scala
+++ b/src/test/scala/akka/persistence/query/journal/redis/Cleanup.scala
@@ -27,7 +27,7 @@ import scala.concurrent.duration._
 trait Cleanup {
   this: AkkaSpec =>
 
-  override def beforeTermination() {
+  override def beforeTermination(): Unit = {
     val redis = RedisUtils.create(ConfigFactory.load.getConfig("akka-persistence-redis"))
     Await.result(redis.eval(
       "return redis.call('del', unpack(redis.call('keys', ARGV[1])))",

--- a/src/test/scala/akka/persistence/query/journal/redis/EventsByPersistenceIdSpec.scala
+++ b/src/test/scala/akka/persistence/query/journal/redis/EventsByPersistenceIdSpec.scala
@@ -26,7 +26,7 @@ import akka.testkit.ImplicitSender
 
 object EventsByPersistenceIdSpec {
   val config = """
-    akka.loglevel = INFO
+    akka.loglevel = INFO 
     akka.persistence.journal.plugin = "akka-persistence-redis.journal"
     akka.test.single-expect-default = 10s
     """

--- a/src/test/scala/akka/testkit/AkkaSpec.scala
+++ b/src/test/scala/akka/testkit/AkkaSpec.scala
@@ -39,7 +39,7 @@ object AkkaSpec {
                                                     """)
 
   def mapToConfig(map: Map[String, Any]): Config = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     ConfigFactory.parseMap(map.asJava)
   }
 
@@ -47,8 +47,8 @@ object AkkaSpec {
     val s = (Thread.currentThread.getStackTrace map (_.getClassName) drop 1)
       .dropWhile(_ matches "(java.lang.Thread|.*AkkaSpec.?$|.*StreamSpec.?$)")
     val reduced = s.lastIndexWhere(_ == clazz.getName) match {
-      case -1 ⇒ s
-      case z  ⇒ s drop (z + 1)
+      case -1 => s
+      case z  => s drop (z + 1)
     }
     reduced.head.replaceFirst(""".*\.""", "").replaceAll("[^a-zA-Z_0-9]", "_")
   }
@@ -75,25 +75,25 @@ abstract class AkkaSpec(_system: ActorSystem)
 
   override val invokeBeforeAllAndAfterAllEvenIfNoTestsAreExpected = true
 
-  final override def beforeAll {
-    startCoroner
+  final override def beforeAll: Unit = {
+    startCoroner()
     atStartup()
   }
 
-  final override def afterAll {
+  final override def afterAll: Unit = {
     beforeTermination()
     shutdown()
     afterTermination()
     stopCoroner()
   }
 
-  protected def atStartup() {}
+  protected def atStartup(): Unit = {}
 
-  protected def beforeTermination() {}
+  protected def beforeTermination(): Unit = {}
 
-  protected def afterTermination() {}
+  protected def afterTermination(): Unit = {}
 
-  def spawn(dispatcherId: String = Dispatchers.DefaultDispatcherId)(body: ⇒ Unit): Unit =
+  def spawn(dispatcherId: String = Dispatchers.DefaultDispatcherId)(body: => Unit): Unit =
     Future(body)(system.dispatchers.lookup(dispatcherId))
 
   override def expectedTestDuration: FiniteDuration = 60 seconds

--- a/src/test/scala/akka/testkit/Coroner.scala
+++ b/src/test/scala/akka/testkit/Coroner.scala
@@ -59,7 +59,7 @@ object Coroner {
     }
 
     override def result(atMost: Duration)(implicit permit: CanAwait): Boolean =
-      try { Await.result(cancelPromise.future, atMost) } catch { case _: TimeoutException ⇒ false }
+      try { Await.result(cancelPromise.future, atMost) } catch { case _: TimeoutException => false }
 
   }
 
@@ -90,7 +90,7 @@ object Coroner {
           watchedHandle.expired()
           out.println(s"Coroner not cancelled after ${duration.toMillis}ms. Looking for signs of foul play...")
           try printReport(reportTitle, out) catch {
-            case NonFatal(ex) ⇒ {
+            case NonFatal(ex) => {
               out.println("Error displaying Coroner's Report")
               ex.printStackTrace(out)
             }
@@ -112,7 +112,7 @@ object Coroner {
 
   /** Print a report containing diagnostic information.
    */
-  def printReport(reportTitle: String, out: PrintStream) {
+  def printReport(reportTitle: String, out: PrintStream): Unit = {
     import out.println
 
     val osMx = ManagementFactory.getOperatingSystemMXBean()
@@ -132,7 +132,7 @@ object Coroner {
     def dumpAllThreads: Seq[ThreadInfo] = {
       threadMx.dumpAllThreads(
         threadMx.isObjectMonitorUsageSupported,
-        threadMx.isSynchronizerUsageSupported)
+        threadMx.isSynchronizerUsageSupported).toIndexedSeq
     }
 
     def findDeadlockedThreads: (Seq[ThreadInfo], String) = {
@@ -145,7 +145,7 @@ object Coroner {
         (Seq.empty, desc)
       } else {
         val maxTraceDepth = 1000 // Seems deep enough
-        (threadMx.getThreadInfo(ids, maxTraceDepth), desc)
+        (threadMx.getThreadInfo(ids, maxTraceDepth).toIndexedSeq, desc)
       }
     }
 
@@ -153,7 +153,7 @@ object Coroner {
       if (threadInfos.isEmpty) {
         println("None")
       } else {
-        for (ti ← threadInfos.sortBy(_.getThreadName)) { println(threadInfoToString(ti)) }
+        for (ti <- threadInfos.sortBy(_.getThreadName)) { println(threadInfoToString(ti)) }
       }
     }
 
@@ -194,27 +194,27 @@ object Coroner {
       }
 
       val stackTrace = ti.getStackTrace
-      for (i ← 0 until stackTrace.length) {
+      for (i <- 0 until stackTrace.length) {
         val ste = stackTrace(i)
         appendMsg("\tat ", ste)
         if (i == 0 && ti.getLockInfo != null) {
           import java.lang.Thread.State._
           ti.getThreadState match {
-            case BLOCKED       ⇒ appendMsg("\t-  blocked on ", ti.getLockInfo)
-            case WAITING       ⇒ appendMsg("\t-  waiting on ", ti.getLockInfo)
-            case TIMED_WAITING ⇒ appendMsg("\t-  waiting on ", ti.getLockInfo)
-            case _             ⇒
+            case BLOCKED       => appendMsg("\t-  blocked on ", ti.getLockInfo)
+            case WAITING       => appendMsg("\t-  waiting on ", ti.getLockInfo)
+            case TIMED_WAITING => appendMsg("\t-  waiting on ", ti.getLockInfo)
+            case _             =>
           }
         }
 
-        for (mi ← ti.getLockedMonitors if mi.getLockedStackDepth == i)
+        for (mi <- ti.getLockedMonitors if mi.getLockedStackDepth == i)
           appendMsg("\t-  locked ", mi)
       }
 
       val locks = ti.getLockedSynchronizers
-      if (locks.length > 0) {
+      if (locks.nonEmpty) {
         appendMsg("\n\tNumber of locked synchronizers = ", locks.length)
-        for (li ← locks) appendMsg("\t- ", li)
+        for (li <- locks) appendMsg("\t- ", li)
       }
       sb.append('\n')
       sb.toString
@@ -239,16 +239,16 @@ object Coroner {
  *  counts during start and stop.
  */
 trait WatchedByCoroner {
-  self: TestKit ⇒
+  self: TestKit =>
 
   @volatile private var coronerWatch: Coroner.WatchHandle = _
 
-  final def startCoroner() {
+  final def startCoroner(): Unit = {
     coronerWatch = Coroner.watch(expectedTestDuration.dilated, getClass.getName, System.err,
       startAndStopDuration.dilated, displayThreadCounts)
   }
 
-  final def stopCoroner() {
+  final def stopCoroner(): Unit = {
     coronerWatch.cancel()
     coronerWatch = null
   }


### PR DESCRIPTION
- Upgrade dependencies
- Change sources to be compatible with Scala 2.11, 2.12 and 2.13
- Fix deprecation issues related to arrows and procedure syntax.

For more information see https://github.com/scala/scala/releases/tag/v2.13.0